### PR TITLE
Added a check to see if the environment has not been created yet

### DIFF
--- a/rainmaker-start.sh
+++ b/rainmaker-start.sh
@@ -3,9 +3,13 @@
 script_dir=$(dirname $0)
 cd $script_dir
 
-if [[ $(vagrant status | fgrep poweroff) == "" ]]; then
-    echo 'Rainmaker is already running'
-    exit 1
+STATUS="$(vagrant status)"
+
+if [[ $(echo "$STATUS" | fgrep poweroff) == "" ]]; then
+    if [[ ! $(echo "$STATUS" | fgrep "The environment has not yet been created") ]]; then
+        echo 'Rainmaker is already running'
+        exit 1
+    fi
 fi
 
 vagrant up


### PR DESCRIPTION
After running install.sh for the first time, vagrant up has yet to be run for the first time.

The instructions say to run ./rainmaker-start.sh but this exits saying *Rainmaker is already running* even though it is not.

Needs a check in the rainmaker-start.sh to check if the environment has been created yet - suggested method in pull request