### PR TITLE
Add a message to inform the user that rainmaker started successfully

### DIFF
--- a/rainmaker-start.sh
+++ b/rainmaker-start.sh
@@ -11,3 +11,5 @@ fi
 vagrant up
 
 ./mount-nfs.sh
+
+echo "Rainmaker was started successfully"


### PR DESCRIPTION
I wasn't sure if something had gone wrong first time rainmaker-start.sh made it through to the end. Suggest there is a friendly message waiting at the end of the process if all is well.